### PR TITLE
Add -fcommon to CFLAGS for GCC 10+ compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC      := gcc
-CFLAGS  := -MMD -O2 -I./include -Wall -Werror
+CFLAGS  := -MMD -O2 -I./include -Wall -Werror -fcommon
 LDFLAGS := -lallegro -lallegro_main -lallegro_primitives
 
 CFILES  := $(shell find src -name "*.c")
@@ -9,7 +9,7 @@ build/%.o: src/%.c
 	@echo + CC $< "->" $@
 	@mkdir -p $(dir $@)
 	@$(CC) $(CFLAGS) -c -o $@ $<
- 
+
 litenes: $(OBJS)
 	@echo + LD "->" $@
 	@$(CC) $(OBJS) $(LDFLAGS) -o litenes


### PR DESCRIPTION
### Summary
This change adds the `-fcommon` flag to our build configuration to maintain compatibility with GCC version 10 and above. The newer versions of GCC default to `-fno-common`, which leads to multiple definition errors for projects that relied on the older `-fcommon` behavior.

### Details
- GCC 10 and later versions have changed the default setting from `-fcommon` to `-fno-common`. This affects the handling of multiple definitions of the same global variable across different files, which previously were silently merged but now cause build errors.
- By explicitly setting `-fcommon` in our build scripts, we ensure that our code will continue to compile without errors across all supported versions of GCC.
- This is particularly important for legacy codebases or projects with multiple definitions of the same variables across different files.

### Impact
- Ensures build stability and backward compatibility with older GCC versions.
- Prevents multiple definition errors during the linking phase when using GCC 10 or newer.

Please review the changes and merge if everything is in order. Feedback is welcome!
